### PR TITLE
[EarlyBird] Fix String casted to long

### DIFF
--- a/src/main/java/com/github/hokkaydo/eplbot/module/earlybird/EarlyBirdNextMessageCommand.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/earlybird/EarlyBirdNextMessageCommand.java
@@ -24,8 +24,8 @@ public class EarlyBirdNextMessageCommand implements Command {
         if(messageOpt.isEmpty()) return;
         if(!context.interaction().isGuildCommand() || context.interaction().getGuild() == null) return;
         long guildId = context.interaction().getGuild().getIdLong();
-        long earlyBirdRoleId = Config.<Long>getGuildVariable(guildId, "EARLY_BIRD_ROLE_ID");
-        if(context.author().getRoles().stream().filter(r -> r.getIdLong() == earlyBirdRoleId).findFirst().isEmpty()) {
+        String earlyBirdRoleId = Config.getGuildVariable(guildId, "EARLY_BIRD_ROLE_ID");
+        if(context.author().getRoles().stream().filter(r -> r.getId().equals(earlyBirdRoleId)).findFirst().isEmpty()) {
             context.replyCallbackAction().setContent(Strings.getString("EARLY_BIRD_NOT_EARLY_BIRD")).queue();
             return;
         }

--- a/src/main/java/com/github/hokkaydo/eplbot/module/earlybird/EarlyBirdNextMessageCommand.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/earlybird/EarlyBirdNextMessageCommand.java
@@ -46,7 +46,7 @@ public class EarlyBirdNextMessageCommand implements Command {
 
     @Override
     public List<OptionData> getOptions() {
-        return Collections.singletonList(new OptionData(OptionType.STRING, "message", "Prochain message matinal que le bot enverra"));
+        return Collections.singletonList(new OptionData(OptionType.STRING, "message", "Prochain message matinal que le bot enverra", true));
     }
 
     @Override


### PR DESCRIPTION
- A cast from String to Long remained since the last config reorganization
- The earlybirdnextmessage command's option "message" is now required (could lead to no response (aka error) for the user)