### PR TITLE
Quick fix on examsretrieve

### DIFF
--- a/src/main/java/com/github/hokkaydo/eplbot/module/graderetrieve/ExamsRetrieveListener.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/graderetrieve/ExamsRetrieveListener.java
@@ -38,14 +38,14 @@ import java.util.zip.ZipOutputStream;
 
 public class ExamsRetrieveListener extends ListenerAdapter {
 
-    private static final Path ZIP_PATH = Path.of(Main.PERSISTENCE_DIR_PATH + "/exams.zip");
+    static final Path ZIP_PATH = Path.of(Main.PERSISTENCE_DIR_PATH + "/exams.zip");
     private static final String THREAD_MESSAGE_FORMAT = "%s - %s (BAC%d - %s)";
     private static final String EXAMEN_STORING_PATH_FORMAT = "%s/Q%d/%s";
     private final Long guildId;
     private Long examsRetrieveChannelId;
     private int selectedQuarterToRetrieve = 1;
     private final CourseGroupRepository groupRepository;
-    private final String zipMessageId;
+    private String zipMessageId;
     private final ExamRetrieveThreadRepository repository;
 
     ExamsRetrieveListener(Long guildId) {
@@ -154,7 +154,8 @@ public class ExamsRetrieveListener extends ListenerAdapter {
         }
         if(zipMessageId.isBlank()) {
             channel.sendMessage("Archive d'examens de cette session").addFiles(FileUpload.fromData(ZIP_PATH)).queue(m -> {
-                Config.updateValue(guildId, "EXAM_ZIP_MESSAGE_ID", zipMessageId);
+                this.zipMessageId = m.getId();
+                Config.updateValue(guildId, "EXAM_ZIP_MESSAGE_ID", m.getId());
                 m.pin().queue();
             });
             return;

--- a/src/main/java/com/github/hokkaydo/eplbot/module/graderetrieve/SetupRetrieveChannelCommand.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/graderetrieve/SetupRetrieveChannelCommand.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,10 @@ public class SetupRetrieveChannelCommand implements Command {
     public void executeCommand(CommandContext context) {
         Optional<OptionMapping> quarterOpt = context.options().stream().filter(e -> e.getName().equals("quarter")).findFirst();
         if(quarterOpt.isEmpty()) return;
+        Config.updateValue(guildId, "EXAM_ZIP_MESSAGE_ID", "");
+        File zip = new File(ExamsRetrieveListener.ZIP_PATH.toUri());
+        if(zip.exists())
+            zip.delete();
         examsRetrieveListener.setGradeRetrieveChannelId(context.channel().getIdLong(), quarterOpt.get().getAsInt());
         Config.updateValue(guildId, "EXAM_RETRIEVE_CHANNEL_ID", context.channel().getId());
     }


### PR DESCRIPTION
- Register zip message id in guild's state
- Delete old zip file on new retrieve threads creation
- Clean old values (zip message id) on new retrieve threads creation