### PR TITLE
adding spoiler + execution time + better\n formatting

### DIFF
--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/c/run_c.sh
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/c/run_c.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo -e "$1" > main.c
+echo -e "${1//\\/\\\\}" > main.c
 # gnu99, the version to be used for lepl1503
 gcc -std=gnu99 -o main main.c -Wall -Werror
 ./main

--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/command/CodeCommand.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/command/CodeCommand.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.interactions.modals.Modal;
 import net.dv8tion.jda.api.interactions.modals.ModalMapping;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -77,18 +78,21 @@ public class CodeCommand extends ListenerAdapter implements Command {
 
     @Override
     public void executeCommand(CommandContext context) {
-
-        if (context.options().size() <= 1) {
+        if (context.options().size() <= 1 || (context.options().size() == 2 && context.options().get(1).getType() != OptionType.ATTACHMENT)) {
             // No file given
             String currentLang = context.options().getFirst().getAsString();
-            context.interaction().replyModal(Modal.create(STR."\{context.author().getId()}-code_submission-\{currentLang}","Execute du code")
+            String modalName = STR."\{context.author().getId()}-code_submission-\{currentLang}";
+            if (context.options().size() == 2){
+                modalName += "-spoiler";
+            }
+            context.interaction().replyModal(Modal.create(modalName,"Execute du code")
                                                      .addActionRow(TextInput.create("body", "Code", TextInputStyle.PARAGRAPH).setPlaceholder("Code").setRequired(true).build())
                                                      .build()).queue();
             return;
         }
-        context.replyCallbackAction().setContent(STR."Processing since: <t:\{Instant.now().getEpochSecond()}:R>").setEphemeral(false).queue();
-        context.options()
-            .get(1)
+        long current = Instant.now().toEpochMilli();
+        context.replyCallbackAction().setContent(STR."Processing since: <t:\{current/ 1000}:R>").setEphemeral(false).queue( reply -> context.options()
+            .get(2)
             .getAsAttachment()
             .getProxy()
             .downloadToFile(new File((INPUT_FILENAME)))
@@ -102,13 +106,16 @@ public class CodeCommand extends ListenerAdapter implements Command {
                         "COMMAND_CODE_TIMELIMIT"
                     ))
                 );
+                boolean hasSpoiler = context.options().get(1).getAsBoolean();
 
                 futureResult.thenAccept(result -> {
-                    response.sendSubmittedCode(context.channel(), code, context.options().getFirst().getAsString());
-                    response.sendResult(context.channel(), result.getLeft(), result.getRight());
+                    response.sendSubmittedCode(context.channel(), spoilMessage(code, hasSpoiler), context.options().getFirst().getAsString());
+                    response.sendResult(context.channel(), spoilMessage(result.getLeft(),hasSpoiler), result.getRight());
                     if (file != null && !file.delete()) {
                         Main.LOGGER.log(Level.INFO, "File not deleted");
                     }
+                    long sent = Instant.now().toEpochMilli();
+                    reply.editOriginal(STR."Processing time: `\{(sent-current)} ms`").queue();
                 });
             })
             .exceptionally(t -> {
@@ -116,8 +123,8 @@ public class CodeCommand extends ListenerAdapter implements Command {
                     \{Strings.getString("COMMAND_CODE_UNEXPECTED_ERROR")}
                     The error is :\{t.getMessage()}""").queue();
                 return null;
-            });
-
+            })
+        );
     }
 
     /**
@@ -134,6 +141,19 @@ public class CodeCommand extends ListenerAdapter implements Command {
         }
     }
 
+    /**
+     * @param text the string to be formatted to spoiler
+     * @param isSpoiler a boolean descibing the need for format
+     * @return the text + || twice
+     */
+    private String spoilMessage(String text, boolean isSpoiler) {
+        if (isSpoiler) {
+            return STR."||\{text}||";
+        } else {
+            return text;
+        }
+    }
+
     @Override
     public void onModalInteraction(ModalInteractionEvent event) {
         // Check for a valid modal
@@ -146,20 +166,25 @@ public class CodeCommand extends ListenerAdapter implements Command {
             return;
         }
         Integer runTimeout = Config.getGuildVariable(guild.getIdLong(), "COMMAND_CODE_TIMELIMIT");
-        event.getInteraction().reply(STR."Processing since: <t:\{Instant.now().getEpochSecond()}:R>").queue();
-        String languageOption = event.getModalId().split("-")[2];
-        String code = Objects.requireNonNull(body.get().getAsString());
-        Runner runner = instantiateRunner(languageOption);
-        CompletableFuture<Pair<String, Integer>> futureResult = CompletableFuture.supplyAsync(() ->
-            runner.run(code, runTimeout)
-        );
-        futureResult.thenAccept(result -> {
-            response.sendSubmittedCode(event.getChannel(),code,languageOption);
-            response.sendResult(event.getChannel(), result.getLeft(),result.getRight());
+        long current = Instant.now().toEpochMilli();
+        event.getInteraction().reply(STR."Processing since: <t:\{current/ 1000}:R>").queue(reply -> {
+            String languageOption = event.getModalId().split("-")[2];
+
+            String code = Objects.requireNonNull(body.get().getAsString());
+            Runner runner = instantiateRunner(languageOption);
+            CompletableFuture<Pair<String, Integer>> futureResult = CompletableFuture.supplyAsync(() ->
+                runner.run(code, runTimeout)
+            );
+            futureResult.thenAccept(result -> {
+                boolean hasSpoiler = event.getModalId().contains("spoiler");
+                response.sendSubmittedCode(event.getChannel(),spoilMessage(code, hasSpoiler),languageOption);
+                response.sendResult(event.getChannel(), spoilMessage(result.getLeft(),hasSpoiler),result.getRight());
+                long sent = Instant.now().toEpochMilli();
+                reply.editOriginal(STR."Processing time: `\{(sent-current)} ms`").queue();
+            });
         });
-
-
     }
+
 
     @Override
     public String getName() {
@@ -179,8 +204,8 @@ public class CodeCommand extends ListenerAdapter implements Command {
         }
         return List.of(
             codeOptions,
+            new OptionData(OptionType.BOOLEAN, "spoiler", Strings.getString("COMMAND_CODE_SPOILER_OPTION_DESCRIPTION"), true),
             new OptionData(OptionType.ATTACHMENT, "file", Strings.getString("COMMAND_CODE_FILE_OPTION_DESCRIPTION"), false)
-
         );
     }
 

--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/java/run_java.sh
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/java/run_java.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-echo -e "$1" > Main.java
+echo -e "${1//\\/\\\\}" > Main.java
 javac Main.java
 java Main

--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/python/PythonRunner.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/python/PythonRunner.java
@@ -13,36 +13,6 @@ public class PythonRunner implements Runner {
     }
     @Override
     public Pair<String, Integer> run(String code, Integer timeout) {
-        return this.runner.run(parseBackslashChars(code), timeout);
-    }
-
-    /**
-     * Simple function to parse the \, as the given code trough discord contains \n maybe inside the strings
-     * that needs to be seen as \\n to be written inside the docker
-     * @param code the code to parse
-     * @return a string where "\n" becomes "\\n"
-     */
-    public static String parseBackslashChars(String code){
-        if (code.isEmpty()){  //checks to avoid IndexOutOfBoundException being thrown  when creating the isInString bool
-            return code;
-        }
-        StringBuilder result = new StringBuilder();
-        result.append(code.charAt(0));
-        boolean isInString = (code.charAt(0) == '\'' || code.charAt(0) == '\"');
-        // we start at index 1 because the code sent might begin with " which would be ignored to avoid an error
-        // when checking for charAt(i-1), see commit 7bd90cea92d5f5a54e8af2529b59c519a7b7662a for a more
-        // concise implementation that could break with a code starting with "
-        for (int i = 1; i < code.length(); i++){
-            Character c = code.charAt(i);
-            if ((c == '\'' || c == '\"') && (code.charAt(i-1) != '\\')){ // checks for "..." or '...' but not "\""
-                isInString = !isInString;
-            }
-            if (isInString && c == '\\'){
-                result.append("\\\\");
-                continue;
-            }
-            result.append(c);
-        }
-        return result.toString();
+        return this.runner.run(code, timeout);
     }
 }

--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/python/run_python.sh
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/python/run_python.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo -e "$1" > main.py
+echo -e "${1//\\/\\\\}" > main.py
 python main.py

--- a/src/main/resources/strings.json
+++ b/src/main/resources/strings.json
@@ -138,6 +138,7 @@
   "COMMAND_CODE_DESCRIPTION":"Execute du code en envoyant des fichier lisibles ex : .txt",
   "COMMAND_CODE_LANG_OPTION_DESCRIPTION":"Le language choisi",
   "COMMAND_CODE_FILE_OPTION_DESCRIPTION":"Le fichier compilé et executé, doit être lié a un language",
+  "COMMAND_CODE_SPOILER_OPTION_DESCRIPTION": "Le code et le résultat est-il en spoiler?",
   "COMMAND_CODE_HELP":"Permet de compiler et exécuter du code en : ",
   "COMMAND_CODE_NO_LANGUAGE_SPECIFIED": "Uh oh, il semble qu'un des problèmes suivants aie surgi : aucun code n'a été soumis ou l'interaction a été trop longue. Pour résoudre ce problème, veuillez réessayer. Si le problème persiste, veuillez contacter un administrateur.",
   "COMMAND_CODE_EXCEEDED_HASTEBIN_SIZE":"La sortie dépasse les 350.000 caractères, nous ne pouvons l'envoyer",


### PR DESCRIPTION
fixing recent issues :

#87 : adding a spoiler parameter (boolean) to add || to the response and submitted code

#90 : similarly requested to  #87, the processing since is replaced by "Processing since :"

#92 : fix for error when matching parentheses with \n, now fixed for every language using a better echo command when initializing the dockers `echo -e "${1//\\/\\\\}" > {file}`
![image](https://github.com/user-attachments/assets/e01a4a95-22db-4656-b4f0-e12f4051d895)
