### PR TITLE
adding a memory usage limit for every dockers

### DIFF
--- a/src/main/java/com/github/hokkaydo/eplbot/module/code/GlobalRunner.java
+++ b/src/main/java/com/github/hokkaydo/eplbot/module/code/GlobalRunner.java
@@ -66,7 +66,17 @@ public class GlobalRunner implements Runner{
 
     private Process startProcessInDocker(String code) throws IOException {
         ProcessBuilder processBuilder = new ProcessBuilder(
-                "docker", "run", "--rm", "-v", "/tmp/logs:/usr/src/app/logs","--name", dockerName, targetDocker, code);
+            "docker", "run", "--rm",
+            "-v", "/tmp/logs:/usr/src/app/logs",
+            "--name", dockerName,
+            "--memory", "512m",           // 512 Mo
+            "--cpus", "1",                // 1 cpu
+            "--pids-limit", "4",        // max 4 processes
+            "--cap-drop=ALL",             // no more linux cmd like mount
+            "--network", "none",          // no network
+            targetDocker,
+            code
+        );
         processBuilder.redirectErrorStream(true);
         return processBuilder.start();
     }


### PR DESCRIPTION
adding memory limit ot 512 mb, number of cpus to 1, max 4 processes, no mount, kill or usermod etc and no internet connection 


all in the docker processbuilder

```java
        ProcessBuilder processBuilder = new ProcessBuilder(
            "docker", "run", "--rm",
            "-v", "/tmp/logs:/usr/src/app/logs",
            "--name", dockerName,
            "--memory", "512m",           // 512 Mo
            "--cpus", "1",                // 1 cpu
            "--pids-limit", "4",          // max 4 processes
            "--cap-drop=ALL",             // no more linux cmd like mount
            "--network", "none",          // no network
            targetDocker,
            code
        );
```